### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name='iosxr_grpc',
-      version='1.1',
+      version='1.2',
       description='gRPC library for IOS-XR > 6.1.1',
       url='https://github.com/cisco-grpc-connection-libs/ios-xr-grpc-python',
       author='Karthik Kumaravel',
@@ -10,6 +10,6 @@ setup(name='iosxr_grpc',
       licencse='Apache 2.0',
       packages=['iosxr_grpc'],
       install_requires=[
-          'grpcio==1.1.0',
+          'grpcio==1.0.0',
       ],
       zip_safe=False)


### PR DESCRIPTION
grpcio above 1.0.0 is not stable on IOS-XR at this time, We are defaulting to using only 1.0.0 for the time being. Changed from 1.1.0 which sometimes works. 